### PR TITLE
feat: Add DragonToDo VS Code theme

### DIFF
--- a/vscode-theme/.vscodeignore
+++ b/vscode-theme/.vscodeignore
@@ -1,0 +1,4 @@
+.vscode/**
+.git/**
+.gitignore
+*.vsix

--- a/vscode-theme/README.md
+++ b/vscode-theme/README.md
@@ -1,0 +1,118 @@
+# DragonToDo Theme for VS Code
+
+A dark, nature-inspired VS Code theme featuring colors from the depths of the swamp and the power of dragons.
+
+## Color Palette
+
+The DragonToDo theme uses a carefully crafted color palette inspired by swamp depths and dragon mythology:
+
+### Swamp Depths (Background)
+- **Deep**: `#0D120E` - Main background
+- **Surface**: `#1A261F` - Secondary background
+- **Highlight**: `#28382D` - Highlighted elements
+- **Border**: `#3A4D3F` - Borders and dividers
+
+### Dragon Bone (Text)
+- **Primary**: `#E6E8E3` - Main text
+- **Secondary**: `#C5C9C0` - Secondary text
+- **Muted**: `#9DA698` - Comments and muted text
+
+### Venom (Primary Colors)
+- **Primary**: `#4E9F58` - Keywords and primary UI elements
+- **Hover**: `#76C782` - Hover states and functions
+- **Dark**: `#2F6F3E` - Darker accents
+- **Teal**: `#8FBCBB` - Links and special highlights
+
+### Hellfire (Status Colors)
+- **Error**: `#BF616A` - Errors and deletions
+- **Warning**: `#D08770` - Warnings and modifications
+- **Notify**: `#EBCB8B` - Strings and notifications
+- **Magic**: `#B48EAD` - Constants and special values
+
+## Installation
+
+### Option 1: Install from VSIX (Recommended)
+
+1. Package the theme:
+   ```bash
+   cd vscode-theme
+   vsce package
+   ```
+
+2. Install the generated `.vsix` file:
+   - Open VS Code
+   - Press `Ctrl+Shift+P` (or `Cmd+Shift+P` on macOS)
+   - Type "Extensions: Install from VSIX"
+   - Select the `dragon-todo-theme-1.0.0.vsix` file
+
+### Option 2: Manual Installation
+
+1. Copy the `vscode-theme` folder to your VS Code extensions directory:
+   - **Windows**: `%USERPROFILE%\.vscode\extensions\`
+   - **macOS/Linux**: `~/.vscode/extensions/`
+
+2. Rename the folder to `dragontodo.dragon-todo-theme-1.0.0`
+
+3. Restart VS Code
+
+### Option 3: Development Mode
+
+1. Open the `vscode-theme` folder in VS Code
+2. Press `F5` to launch a new VS Code window with the theme loaded
+3. In the new window, select the theme:
+   - Press `Ctrl+K Ctrl+T` (or `Cmd+K Cmd+T` on macOS)
+   - Select "DragonToDo Dark"
+
+## Activation
+
+1. Open the Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P`)
+2. Type "Preferences: Color Theme"
+3. Select "DragonToDo Dark"
+
+Or use the keyboard shortcut:
+- `Ctrl+K Ctrl+T` (Windows/Linux)
+- `Cmd+K Cmd+T` (macOS)
+
+## Features
+
+- **Carefully selected colors** designed for long coding sessions with reduced eye strain
+- **Semantic highlighting** with distinct colors for different code elements
+- **Comprehensive UI theming** covering editor, sidebar, terminal, and more
+- **Git integration** with color-coded file status indicators
+- **Consistent color usage** across all VS Code components
+
+## Screenshots
+
+The theme features:
+- Deep, dark backgrounds inspired by swamp depths
+- Vibrant green accents from dragon venom
+- Warm warning colors from hellfire
+- Clean, readable text in dragon bone white
+
+## Recommended Settings
+
+For the best experience with DragonToDo Theme, consider these VS Code settings:
+
+```json
+{
+  "editor.fontFamily": "'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace",
+  "editor.fontSize": 14,
+  "editor.lineHeight": 22,
+  "editor.fontLigatures": true,
+  "editor.cursorBlinking": "smooth",
+  "editor.cursorSmoothCaretAnimation": "on",
+  "workbench.iconTheme": "material-icon-theme"
+}
+```
+
+## Contributing
+
+Found an issue or have a suggestion? Please open an issue on the [GitHub repository](https://github.com/jskoll/DragonToDo).
+
+## License
+
+MIT License - See LICENSE file for details
+
+## Credits
+
+Created for the DragonToDo project - A modern, encrypted todo.txt manager.

--- a/vscode-theme/package.json
+++ b/vscode-theme/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "dragon-todo-theme",
+  "displayName": "DragonToDo Theme",
+  "description": "A dark VS Code theme inspired by DragonToDo's swamp depths and dragon colors",
+  "version": "1.0.0",
+  "publisher": "dragontodo",
+  "engines": {
+    "vscode": "^1.60.0"
+  },
+  "categories": [
+    "Themes"
+  ],
+  "keywords": [
+    "theme",
+    "dark theme",
+    "dragon",
+    "productivity",
+    "green"
+  ],
+  "contributes": {
+    "themes": [
+      {
+        "label": "DragonToDo Dark",
+        "uiTheme": "vs-dark",
+        "path": "./themes/dragon-todo-dark.json"
+      }
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jskoll/DragonToDo"
+  },
+  "license": "MIT",
+  "icon": "icon.png"
+}

--- a/vscode-theme/themes/dragon-todo-dark.json
+++ b/vscode-theme/themes/dragon-todo-dark.json
@@ -1,0 +1,494 @@
+{
+  "name": "DragonToDo Dark",
+  "type": "dark",
+  "colors": {
+    "editor.background": "#0D120E",
+    "editor.foreground": "#E6E8E3",
+    "activityBar.background": "#0D120E",
+    "activityBar.foreground": "#E6E8E3",
+    "activityBar.inactiveForeground": "#9DA698",
+    "activityBar.border": "#3A4D3F",
+    "activityBarBadge.background": "#4E9F58",
+    "activityBarBadge.foreground": "#0D120E",
+    "sideBar.background": "#1A261F",
+    "sideBar.foreground": "#C5C9C0",
+    "sideBar.border": "#3A4D3F",
+    "sideBarTitle.foreground": "#E6E8E3",
+    "sideBarSectionHeader.background": "#28382D",
+    "sideBarSectionHeader.foreground": "#E6E8E3",
+    "sideBarSectionHeader.border": "#3A4D3F",
+    "list.activeSelectionBackground": "#28382D",
+    "list.activeSelectionForeground": "#E6E8E3",
+    "list.inactiveSelectionBackground": "#1A261F",
+    "list.inactiveSelectionForeground": "#E6E8E3",
+    "list.hoverBackground": "#28382D",
+    "list.hoverForeground": "#E6E8E3",
+    "list.focusBackground": "#28382D",
+    "list.focusForeground": "#E6E8E3",
+    "list.highlightForeground": "#76C782",
+    "editor.lineHighlightBackground": "#1A261F",
+    "editor.selectionBackground": "#28382D",
+    "editor.selectionHighlightBackground": "#28382D80",
+    "editor.wordHighlightBackground": "#28382D80",
+    "editor.wordHighlightStrongBackground": "#28382D",
+    "editor.findMatchBackground": "#D0877080",
+    "editor.findMatchHighlightBackground": "#D0877040",
+    "editor.findRangeHighlightBackground": "#28382D80",
+    "editorBracketMatch.background": "#28382D",
+    "editorBracketMatch.border": "#4E9F58",
+    "editorCursor.foreground": "#4E9F58",
+    "editorLineNumber.foreground": "#9DA698",
+    "editorLineNumber.activeForeground": "#C5C9C0",
+    "editorIndentGuide.background": "#3A4D3F",
+    "editorIndentGuide.activeBackground": "#4E9F58",
+    "editorWhitespace.foreground": "#3A4D3F",
+    "editorRuler.foreground": "#3A4D3F",
+    "editorLink.activeForeground": "#8FBCBB",
+    "editorWidget.background": "#1A261F",
+    "editorWidget.border": "#3A4D3F",
+    "editorSuggestWidget.background": "#1A261F",
+    "editorSuggestWidget.border": "#3A4D3F",
+    "editorSuggestWidget.foreground": "#E6E8E3",
+    "editorSuggestWidget.highlightForeground": "#76C782",
+    "editorSuggestWidget.selectedBackground": "#28382D",
+    "editorHoverWidget.background": "#1A261F",
+    "editorHoverWidget.border": "#3A4D3F",
+    "editorGroup.border": "#3A4D3F",
+    "editorGroupHeader.tabsBackground": "#0D120E",
+    "editorGroupHeader.tabsBorder": "#3A4D3F",
+    "tab.activeBackground": "#1A261F",
+    "tab.activeForeground": "#E6E8E3",
+    "tab.activeBorder": "#4E9F58",
+    "tab.inactiveBackground": "#0D120E",
+    "tab.inactiveForeground": "#9DA698",
+    "tab.border": "#3A4D3F",
+    "tab.hoverBackground": "#28382D",
+    "tab.unfocusedHoverBackground": "#1A261F",
+    "statusBar.background": "#0D120E",
+    "statusBar.foreground": "#C5C9C0",
+    "statusBar.border": "#3A4D3F",
+    "statusBar.debuggingBackground": "#D08770",
+    "statusBar.debuggingForeground": "#0D120E",
+    "statusBar.noFolderBackground": "#0D120E",
+    "statusBarItem.activeBackground": "#28382D",
+    "statusBarItem.hoverBackground": "#28382D",
+    "statusBarItem.prominentBackground": "#4E9F58",
+    "statusBarItem.prominentHoverBackground": "#76C782",
+    "titleBar.activeBackground": "#0D120E",
+    "titleBar.activeForeground": "#E6E8E3",
+    "titleBar.inactiveBackground": "#0D120E",
+    "titleBar.inactiveForeground": "#9DA698",
+    "titleBar.border": "#3A4D3F",
+    "panel.background": "#0D120E",
+    "panel.border": "#3A4D3F",
+    "panelTitle.activeBorder": "#4E9F58",
+    "panelTitle.activeForeground": "#E6E8E3",
+    "panelTitle.inactiveForeground": "#9DA698",
+    "terminal.background": "#0D120E",
+    "terminal.foreground": "#E6E8E3",
+    "terminal.ansiBlack": "#0D120E",
+    "terminal.ansiRed": "#BF616A",
+    "terminal.ansiGreen": "#4E9F58",
+    "terminal.ansiYellow": "#EBCB8B",
+    "terminal.ansiBlue": "#8FBCBB",
+    "terminal.ansiMagenta": "#B48EAD",
+    "terminal.ansiCyan": "#76C782",
+    "terminal.ansiWhite": "#E6E8E3",
+    "terminal.ansiBrightBlack": "#9DA698",
+    "terminal.ansiBrightRed": "#BF616A",
+    "terminal.ansiBrightGreen": "#76C782",
+    "terminal.ansiBrightYellow": "#EBCB8B",
+    "terminal.ansiBrightBlue": "#8FBCBB",
+    "terminal.ansiBrightMagenta": "#B48EAD",
+    "terminal.ansiBrightCyan": "#76C782",
+    "terminal.ansiBrightWhite": "#E6E8E3",
+    "input.background": "#1A261F",
+    "input.border": "#3A4D3F",
+    "input.foreground": "#E6E8E3",
+    "input.placeholderForeground": "#9DA698",
+    "inputOption.activeBorder": "#4E9F58",
+    "inputValidation.errorBackground": "#BF616A",
+    "inputValidation.errorBorder": "#BF616A",
+    "inputValidation.warningBackground": "#D08770",
+    "inputValidation.warningBorder": "#D08770",
+    "inputValidation.infoBackground": "#8FBCBB",
+    "inputValidation.infoBorder": "#8FBCBB",
+    "dropdown.background": "#1A261F",
+    "dropdown.border": "#3A4D3F",
+    "dropdown.foreground": "#E6E8E3",
+    "button.background": "#4E9F58",
+    "button.foreground": "#0D120E",
+    "button.hoverBackground": "#76C782",
+    "button.secondaryBackground": "#28382D",
+    "button.secondaryForeground": "#E6E8E3",
+    "button.secondaryHoverBackground": "#3A4D3F",
+    "badge.background": "#4E9F58",
+    "badge.foreground": "#0D120E",
+    "progressBar.background": "#4E9F58",
+    "breadcrumb.foreground": "#9DA698",
+    "breadcrumb.background": "#0D120E",
+    "breadcrumb.focusForeground": "#E6E8E3",
+    "breadcrumb.activeSelectionForeground": "#76C782",
+    "breadcrumbPicker.background": "#1A261F",
+    "scrollbar.shadow": "#0D120E",
+    "scrollbarSlider.background": "#3A4D3F80",
+    "scrollbarSlider.hoverBackground": "#3A4D3FA0",
+    "scrollbarSlider.activeBackground": "#4E9F58A0",
+    "menu.background": "#1A261F",
+    "menu.foreground": "#E6E8E3",
+    "menu.selectionBackground": "#28382D",
+    "menu.selectionForeground": "#E6E8E3",
+    "menu.border": "#3A4D3F",
+    "notificationCenter.border": "#3A4D3F",
+    "notificationCenterHeader.background": "#1A261F",
+    "notificationCenterHeader.foreground": "#E6E8E3",
+    "notifications.background": "#1A261F",
+    "notifications.border": "#3A4D3F",
+    "notifications.foreground": "#E6E8E3",
+    "notificationLink.foreground": "#8FBCBB",
+    "notificationToast.border": "#3A4D3F",
+    "notificationsErrorIcon.foreground": "#BF616A",
+    "notificationsWarningIcon.foreground": "#D08770",
+    "notificationsInfoIcon.foreground": "#8FBCBB",
+    "pickerGroup.border": "#3A4D3F",
+    "pickerGroup.foreground": "#4E9F58",
+    "quickInput.background": "#1A261F",
+    "quickInput.foreground": "#E6E8E3",
+    "quickInputList.focusBackground": "#28382D",
+    "settings.headerForeground": "#E6E8E3",
+    "settings.modifiedItemIndicator": "#4E9F58",
+    "settings.dropdownBackground": "#1A261F",
+    "settings.dropdownBorder": "#3A4D3F",
+    "settings.checkboxBackground": "#1A261F",
+    "settings.checkboxBorder": "#3A4D3F",
+    "settings.textInputBackground": "#1A261F",
+    "settings.textInputBorder": "#3A4D3F",
+    "settings.numberInputBackground": "#1A261F",
+    "settings.numberInputBorder": "#3A4D3F",
+    "gitDecoration.modifiedResourceForeground": "#EBCB8B",
+    "gitDecoration.deletedResourceForeground": "#BF616A",
+    "gitDecoration.untrackedResourceForeground": "#76C782",
+    "gitDecoration.ignoredResourceForeground": "#9DA698",
+    "gitDecoration.conflictingResourceForeground": "#D08770",
+    "gitDecoration.submoduleResourceForeground": "#8FBCBB",
+    "debugToolBar.background": "#1A261F",
+    "debugToolBar.border": "#3A4D3F",
+    "debugExceptionWidget.background": "#1A261F",
+    "debugExceptionWidget.border": "#BF616A",
+    "focusBorder": "#4E9F58",
+    "foreground": "#E6E8E3",
+    "selection.background": "#28382D",
+    "widget.shadow": "#0D120E80",
+    "textLink.foreground": "#8FBCBB",
+    "textLink.activeForeground": "#76C782",
+    "textPreformat.foreground": "#C5C9C0",
+    "textBlockQuote.background": "#1A261F",
+    "textBlockQuote.border": "#4E9F58",
+    "textCodeBlock.background": "#1A261F",
+    "textSeparator.foreground": "#3A4D3F",
+    "errorForeground": "#BF616A",
+    "icon.foreground": "#C5C9C0",
+    "peekView.border": "#4E9F58",
+    "peekViewEditor.background": "#1A261F",
+    "peekViewEditorGutter.background": "#0D120E",
+    "peekViewEditor.matchHighlightBackground": "#D0877080",
+    "peekViewResult.background": "#0D120E",
+    "peekViewResult.fileForeground": "#E6E8E3",
+    "peekViewResult.lineForeground": "#C5C9C0",
+    "peekViewResult.matchHighlightBackground": "#D0877080",
+    "peekViewResult.selectionBackground": "#28382D",
+    "peekViewResult.selectionForeground": "#E6E8E3",
+    "peekViewTitle.background": "#0D120E",
+    "peekViewTitleDescription.foreground": "#9DA698",
+    "peekViewTitleLabel.foreground": "#E6E8E3"
+  },
+  "tokenColors": [
+    {
+      "scope": [
+        "comment",
+        "punctuation.definition.comment"
+      ],
+      "settings": {
+        "foreground": "#9DA698",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "scope": [
+        "string",
+        "string.quoted",
+        "string.template"
+      ],
+      "settings": {
+        "foreground": "#EBCB8B"
+      }
+    },
+    {
+      "scope": [
+        "string.regexp"
+      ],
+      "settings": {
+        "foreground": "#D08770"
+      }
+    },
+    {
+      "scope": [
+        "constant.numeric",
+        "constant.language",
+        "constant.character",
+        "constant.other"
+      ],
+      "settings": {
+        "foreground": "#B48EAD"
+      }
+    },
+    {
+      "scope": [
+        "variable",
+        "variable.other"
+      ],
+      "settings": {
+        "foreground": "#E6E8E3"
+      }
+    },
+    {
+      "scope": [
+        "variable.language"
+      ],
+      "settings": {
+        "foreground": "#8FBCBB",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "scope": [
+        "variable.parameter"
+      ],
+      "settings": {
+        "foreground": "#C5C9C0"
+      }
+    },
+    {
+      "scope": [
+        "keyword",
+        "keyword.control",
+        "keyword.operator.new",
+        "keyword.other"
+      ],
+      "settings": {
+        "foreground": "#76C782",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": [
+        "keyword.operator",
+        "keyword.operator.logical",
+        "keyword.operator.arithmetic",
+        "keyword.operator.assignment"
+      ],
+      "settings": {
+        "foreground": "#4E9F58"
+      }
+    },
+    {
+      "scope": [
+        "storage",
+        "storage.type",
+        "storage.modifier"
+      ],
+      "settings": {
+        "foreground": "#76C782",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.function",
+        "meta.function-call",
+        "support.function"
+      ],
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.type",
+        "entity.name.class",
+        "support.type",
+        "support.class"
+      ],
+      "settings": {
+        "foreground": "#76C782"
+      }
+    },
+    {
+      "scope": [
+        "entity.other.inherited-class"
+      ],
+      "settings": {
+        "foreground": "#4E9F58",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.tag"
+      ],
+      "settings": {
+        "foreground": "#4E9F58"
+      }
+    },
+    {
+      "scope": [
+        "entity.other.attribute-name"
+      ],
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "scope": [
+        "support.constant",
+        "support.variable"
+      ],
+      "settings": {
+        "foreground": "#B48EAD"
+      }
+    },
+    {
+      "scope": [
+        "invalid",
+        "invalid.illegal"
+      ],
+      "settings": {
+        "foreground": "#BF616A",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": [
+        "invalid.deprecated"
+      ],
+      "settings": {
+        "foreground": "#D08770",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "scope": [
+        "markup.heading"
+      ],
+      "settings": {
+        "foreground": "#4E9F58",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": [
+        "markup.bold"
+      ],
+      "settings": {
+        "foreground": "#76C782",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": [
+        "markup.italic"
+      ],
+      "settings": {
+        "foreground": "#8FBCBB",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "scope": [
+        "markup.underline.link",
+        "markup.underline"
+      ],
+      "settings": {
+        "foreground": "#8FBCBB",
+        "fontStyle": "underline"
+      }
+    },
+    {
+      "scope": [
+        "markup.quote"
+      ],
+      "settings": {
+        "foreground": "#9DA698",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "scope": [
+        "markup.inline.raw",
+        "markup.fenced_code"
+      ],
+      "settings": {
+        "foreground": "#EBCB8B"
+      }
+    },
+    {
+      "scope": [
+        "markup.deleted"
+      ],
+      "settings": {
+        "foreground": "#BF616A"
+      }
+    },
+    {
+      "scope": [
+        "markup.inserted"
+      ],
+      "settings": {
+        "foreground": "#76C782"
+      }
+    },
+    {
+      "scope": [
+        "markup.changed"
+      ],
+      "settings": {
+        "foreground": "#D08770"
+      }
+    },
+    {
+      "scope": [
+        "punctuation.definition.tag"
+      ],
+      "settings": {
+        "foreground": "#4E9F58"
+      }
+    },
+    {
+      "scope": [
+        "punctuation.section"
+      ],
+      "settings": {
+        "foreground": "#E6E8E3"
+      }
+    },
+    {
+      "scope": [
+        "meta.import",
+        "meta.export"
+      ],
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "scope": [
+        "meta.jsx.children",
+        "meta.tag.tsx",
+        "meta.tag.jsx"
+      ],
+      "settings": {
+        "foreground": "#E6E8E3"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Create a complete VS Code theme extension using the DragonToDo color palette:
- Swamp Depths backgrounds (#0D120E, #1A261F, #28382D, #3A4D3F)
- Dragon Bone text colors (#E6E8E3, #C5C9C0, #9DA698)
- Venom primary colors (#4E9F58, #76C782, #8FBCBB)
- Hellfire status colors (#BF616A, #D08770, #EBCB8B, #B48EAD)

The theme includes:
- Comprehensive UI color mappings for all VS Code components
- Semantic syntax highlighting with distinct token colors
- Git integration colors
- Terminal ANSI color support
- Package configuration for easy installation
- Detailed README with installation instructions